### PR TITLE
Fix a scope issue for the "logged in" flag.

### DIFF
--- a/load.py
+++ b/load.py
@@ -88,6 +88,7 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
     :param is_beta: Whether the player is in a Beta universe.
     :return: Error message.
     """
+    global LOGGED_IN_TO_EDRP
     error = None
     log_source = 'JournalEntry'
     # Check for an event key.


### PR DESCRIPTION
Due to the structure that EDMC requires of the load.py file, any flags need to be set as global variables in order to avoid scoping issues with UnboundLocalError exceptions.